### PR TITLE
feat: deploy all infrastructure in a single command

### DIFF
--- a/metrics.yaml
+++ b/metrics.yaml
@@ -109,3 +109,18 @@ resources:
     notificationChannels:
       - $(ref.backup-notification-channel.name)
     enabled: true
+- type: gcp-types/cloudfunctions-v1beta2:projects.locations.functions
+  name: spanner-create-backup-function
+  properties:
+    location: us-central1
+    function: SpannerCreateBackup
+    sourceArchiveUrl: gs://[gcs_bucket_name]/scheduled-backups.zip
+    entryPoint: SpannerCreateBackup
+    runtime: go113
+    eventTrigger:
+      resource: $(ref.cloud-spanner-scheduled-backups-topic.name)
+      eventType: providers/cloud.pubsub/eventTypes/topic.publish
+- type: gcp-types/pubsub-v1:projects.topics
+  name: cloud-spanner-scheduled-backups-topic
+  properties:
+    topic: cloud-spanner-scheduled-backups

--- a/metrics.yaml
+++ b/metrics.yaml
@@ -35,3 +35,77 @@ resources:
       severity >= ERROR
       protoPayload.methodName="google.spanner.admin.database.v1.DatabaseAdmin.CreateBackup"
       protoPayload.resourceName:"backups/schedule-"
+- type: gcp-types/monitoring-v3:projects.notificationChannels
+  name: backup-notification-channel
+  properties:
+    displayName: Email notification channel
+    enabled: true
+    labels:
+      email_address: nobody+gcptypes@google.com
+    type: email
+- name: backup-cloud-function-alert
+  type: gcp-types/monitoring-v3:projects.alertPolicies
+  properties:
+    combiner: OR
+    conditions:
+    - conditionThreshold:
+        aggregations:
+        - alignmentPeriod: 60s
+          crossSeriesReducer: REDUCE_SUM
+          perSeriesAligner: ALIGN_MEAN
+        comparison: COMPARISON_GT
+        duration: 60s
+        filter: resource.type="cloud_function"
+          AND metric.type="logging.googleapis.com/user/backup-cloud-function-errors"
+        thresholdValue: 0
+        trigger:
+          count: 1
+      displayName: logging/user/backup-cloud-function-errors [SUM]
+    displayName: backup-cloud-function-alert
+    notificationChannels:
+      - $(ref.backup-notification-channel.name)
+    enabled: true
+- name: backup-cloud-scheduler-alert
+  type: gcp-types/monitoring-v3:projects.alertPolicies
+  properties:
+    combiner: OR
+    conditions:
+    - conditionThreshold:
+        aggregations:
+        - alignmentPeriod: 60s
+          crossSeriesReducer: REDUCE_SUM
+          perSeriesAligner: ALIGN_MEAN
+        comparison: COMPARISON_GT
+        duration: 60s
+        filter: resource.type="cloud_scheduler_job"
+          AND metric.type="logging.googleapis.com/user/backup-cloud-scheduler-errors"
+        thresholdValue: 0
+        trigger:
+          count: 1
+      displayName: logging/user/backup-cloud-scheduler-errors [SUM]
+    displayName: backup-cloud-scheduler-alert
+    notificationChannels:
+      - $(ref.backup-notification-channel.name)
+    enabled: true
+- name: backup-cloud-spanner-alert
+  type: gcp-types/monitoring-v3:projects.alertPolicies
+  properties:
+    combiner: OR
+    conditions:
+    - conditionThreshold:
+        aggregations:
+        - alignmentPeriod: 60s
+          crossSeriesReducer: REDUCE_SUM
+          perSeriesAligner: ALIGN_MEAN
+        comparison: COMPARISON_GT
+        duration: 60s
+        filter: resource.type="spanner_instance"
+          AND metric.type="logging.googleapis.com/user/backup-cloud-spanner-errors"
+        thresholdValue: 0
+        trigger:
+          count: 1
+      displayName: logging/user/backup-cloud-spanner-errors [SUM]
+    displayName: backup-cloud-spanner-alert
+    notificationChannels:
+      - $(ref.backup-notification-channel.name)
+    enabled: true


### PR DESCRIPTION
This PR is trying to provision all infrastructure resources in a single command: 

- [x] logs-based-metrics
- [x] alerting policies
- [x] a pub/sub topic
- [x] a function in Cloud Functions
- [ ] scheduled jobs in Cloud Scheduler

Also, a python script template should be used for a flexible config. 

Better not to change the current `metrics.yaml` for not breaking any steps in the [blog post](https://medium.com/@hengfeng/create-cloud-spanner-scheduled-backups-c6f30551a6fd). 

Lastly, consider to make this a GCP marketplace solution so that users do not need to touch any code or commands. 