### PR TITLE
fix: verbosity to the failed read file

### DIFF
--- a/cmd/scheduler/main.go
+++ b/cmd/scheduler/main.go
@@ -68,6 +68,9 @@ func main() {
 		os.Exit(2)
 	}
 	content, err := ioutil.ReadFile(filename)
+	if err != nil {
+		log.Fatalf("Failed to read file: %v", err)
+	}
 
 	var project Project
 


### PR DESCRIPTION
Currently the application only closes when reading a schedule configuration that does not exist. This PR presents an error for client if the file does not exist.

Example problem:
```bash
scheduled-backups $ go run cmd / scheduler / main.go -config schedule.not-found.config.yaml
scheduled-backups $
```